### PR TITLE
Use downcase() only for fact sets which fact a valid operatingsystem

### DIFF
--- a/lib/rspec-puppet-facts-unsupported/on_unsupported_os.rb
+++ b/lib/rspec-puppet-facts-unsupported/on_unsupported_os.rb
@@ -265,7 +265,8 @@ module RspecPuppetFactsUnsupported
     end
 
     def describe_os(facts)
-      "#{facts[:operatingsystem].downcase}-" \
+      os = facts[:operatingsystem] ? facts[:operatingsystem].downcase : 'unknown'
+      "#{os}-" \
         "#{facts[:operatingsystemmajrelease]}-" \
         "#{facts[:hardwaremodel]}"
     end

--- a/spec/rspec-puppet-facts-unsupported/on_unsupported_os_spec.rb
+++ b/spec/rspec-puppet-facts-unsupported/on_unsupported_os_spec.rb
@@ -128,3 +128,14 @@ RSpec.describe 'RspecPuppetFactsUnsupported#on_unsupported_os' do
     it_behaves_like "it doesn't contain supported OS's described in metadata.json"
   end
 end
+
+RSpec.describe RspecPuppetFactsUnsupported::UnsupportedFilteringOperation do
+  describe '#describe_os' do
+    context 'with no facts[:operatingsystem]' do
+      let(:klass) { RspecPuppetFactsUnsupported::UnsupportedFilteringOperation.new({}, {}) }
+      subject { klass.send(:describe_os, operatingsystemmajrelease: '4', hardwaremodel: 'x86_64') }
+
+      it { is_expected.to eq 'unknown-4-x86_64' }
+    end
+  end
+end


### PR DESCRIPTION
facterdb 0.8.1 introduced a SLES 15 SP1 fact set which doesn't have a
operatingsystem fact. This is due to bugs in facter 2.5. As facter 2.5
doesn't get maintance anymore, we need to fail safely here.

Fixes #3.